### PR TITLE
Added FreeDesktop.org metadata

### DIFF
--- a/data/desktop/com.lixgame.Lix.desktop
+++ b/data/desktop/com.lixgame.Lix.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=Lix
+Comment=An action-puzzle game inspired by Lemmings
+Exec=lix
+Icon=com.lixgame.Lix
+Categories=Game;ActionGame;
+Keywords=game;lemmings;

--- a/data/desktop/com.lixgame.Lix.metainfo.xml
+++ b/data/desktop/com.lixgame.Lix.metainfo.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <!--Created with jdAppdataEdit 4.2-->
+  <id>com.lixgame.Lix</id>
+  <name>Lix</name>
+  <summary>Lemmings-like game with puzzles, editor, multiplayer</summary>
+  <developer_name>Simon Naarmann
+</developer_name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>CC0-1.0</project_license>
+  <description>
+    <p>Lix is a puzzle game inspired by Lemmings (DMA Design, 1991). Lix is free and open source.</p>
+    <p>Assign skills to guide the lix through over 700 singleplayer puzzles. Design your own levels with the included editor.</p>
+    <p>Attack and defend in real-time multiplayer for 2 to 8 players: Who can save the most lix?</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">http://lixgame.com/img/lix-d-screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="v0.9.47" date="2022-08-11" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.47</url>
+    </release>
+    <release version="v0.9.46" date="2022-06-25" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.46</url>
+    </release>
+    <release version="v0.9.45" date="2022-05-21" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.45</url>
+    </release>
+    <release version="v0.9.44" date="2022-04-03" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.44</url>
+    </release>
+    <release version="v0.9.43" date="2022-03-29" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.43</url>
+    </release>
+    <release version="v0.9.42" date="2022-02-25" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.42</url>
+    </release>
+    <release version="v0.9.41" date="2022-01-06" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.41</url>
+    </release>
+    <release version="v0.9.40" date="2021-12-13" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.40</url>
+    </release>
+    <release version="v0.9.39" date="2021-10-12" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.39</url>
+    </release>
+    <release version="v0.9.38" date="2021-06-27" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.38</url>
+    </release>
+    <release version="v0.9.37" date="2021-05-17" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.37</url>
+    </release>
+    <release version="v0.9.36" date="2021-02-24" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.36</url>
+    </release>
+    <release version="v0.9.35" date="2020-12-24" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.35</url>
+    </release>
+    <release version="v0.9.34" date="2020-10-11" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.34</url>
+    </release>
+    <release version="v0.9.33" date="2020-08-09" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.33</url>
+    </release>
+    <release version="v0.9.32" date="2020-08-01" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.32</url>
+    </release>
+    <release version="v0.9.31" date="2020-04-23" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.31</url>
+    </release>
+    <release version="v0.9.30" date="2019-12-28" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.30</url>
+    </release>
+    <release version="v0.9.29" date="2019-07-19" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.29</url>
+    </release>
+    <release version="v0.9.28" date="2019-07-07" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.28</url>
+    </release>
+    <release version="v0.9.27" date="2019-05-20" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.27</url>
+    </release>
+    <release version="v0.9.26" date="2019-04-23" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.26</url>
+    </release>
+    <release version="v0.9.25" date="2019-02-04" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.25</url>
+    </release>
+    <release version="v0.9.24" date="2019-01-03" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.24</url>
+    </release>
+    <release version="v0.9.23" date="2018-12-09" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.23</url>
+    </release>
+    <release version="v0.9.22" date="2018-11-30" type="stable">
+      <url>https://github.com/SimonN/LixD/releases/tag/v0.9.22</url>
+    </release>
+  </releases>
+  <url type="homepage">http://www.lixgame.com/</url>
+  <url type="bugtracker">https://github.com/SimonN/LixD/issues</url>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">mild</content_attribute>
+  </content_rating>
+</component>


### PR DESCRIPTION
This adds a [start menu](https://specifications.freedesktop.org/desktop-entry-spec/latest/) and [app store data](https://freedesktop.org/software/appstream/docs/chap-Metadata.html) entry including [OARS](https://hughsie.github.io/oars/) both of which are required for https://github.com/flathub/flathub/pull/3415.