### PR TITLE
Information about unofficial package for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Get Lix
 * Flatpak: [Lix Flathub
     package](https://flathub.org/apps/details/com.lixgame.Lix),
     maintained by Matthias Mailänder
+* Fedora: [Unofficial COPR package](https://copr.fedorainfracloud.org/coprs/szpak/lix/),
+    maintained by Marcin Zajączkowski
 * macOS, other Linuxes, other OSes: Build from source, see below.
 
 Thanks to our awesome package maintainers!

--- a/doc/build/linux.md
+++ b/doc/build/linux.md
@@ -22,6 +22,10 @@ Debian/Ubuntu:
 
     # apt-get install ldc dub
 
+Fedora:
+
+    # dnf install ldc dub
+
 macOS: First, install [Homebrew](https://brew.sh/). Then run
 
     $ brew install ldc dub
@@ -58,7 +62,7 @@ Debian/Ubuntu:
 
     # apt-get install pkgconf liballegro5-dev liballegro-acodec5-dev liballegro-audio5-dev liballegro-image5-dev liballegro-ttf5-dev libenet-dev
 
-Fedora 29:
+Fedora 37:
 
     # dnf install pkgconf-pkg-config allegro5-devel allegro5-addon-acodec-devel allegro5-addon-audio-devel allegro5-addon-image-devel allegro5-addon-ttf-devel enet-devel
 


### PR DESCRIPTION
It's been many years since I first encounter Lix (and was able to run it locally from sources on Fedora) and finally, I've decided to package Lix for Fedora users to make it even more popular (and easier to install :-) ).

Unfortunately, D language, isn't very common in Fedora, so for example the offline caching of dub packages was not trival, but with the help of the SUSE package I was able to do something which seems to work. I uploaded it to COPR, a build system for 3rd-party Fedora packages. It's easy to install it:

```
$ sudo dnf copr enable szpak/lix
$ sudo dnf install lix
```

Once I have some feedback from the users, I might start a path to get Lix into the core Fedora packages.

Btw, the package is available for x86_64 and Arch64. dum/ldc don't seem to be available in Fedora for PPC64 and s390.