### PR TITLE
Fix entrance order in 6P Rescue Ranger Trolls

### DIFF
--- a/levels/network/6p/geoo/rescuerangertrolls.txt
+++ b/levels/network/6p/geoo/rescuerangertrolls.txt
@@ -1,4 +1,4 @@
-$BUILT 2021-05-12 22:05:34
+$BUILT 2024-01-21 20:06:49
 $AUTHOR geoo
 $ENGLISH Rescue Ranger Trolls
 
@@ -26,8 +26,8 @@ $ENGLISH Rescue Ranger Trolls
 #JUMPER 50
 #BATTER -1
 
-:raymanni/lab/hatch.H: 144 16 r
 :raymanni/lab/hatch.H: 46 16
+:raymanni/lab/hatch.H: 144 16 r
 :raymanni/lab/hatch.H: 400 16 r
 :raymanni/lab/hatch.H: 302 16
 :raymanni/lab/hatch.H: 656 16 r


### PR DESCRIPTION
Map wasn't symmetric, two of the six players had to turn their lix while the others did not.